### PR TITLE
Add a travis file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,1 @@
+language: java


### PR DESCRIPTION
if your project has pom.xml file in the repository root but no build.gradle, Travis CI Java builder will use Maven 3 to build it. By default it will use mvn test
